### PR TITLE
[djangocon-2014] md->rst conversion after speaker cleanup

### DIFF
--- a/data/djangocon-2014/category.json
+++ b/data/djangocon-2014/category.json
@@ -1,7 +1,5 @@
 {
-  "title": "DjangoCon 2014", 
-  "description": "DjangoCon US is the main opportunity for djangonauts to come together in the\nUnited States. It will consist of two tracks of talks over three days, and\nwill also provide for open sessions, lightning talks, and a development sprint\nafter the conference.\n\nDjangoCon US provides a critical opportunity for the community members to\nsocialize, share ideas, work together, and plan for continued success.\n\n", 
-  "url": "https://2014.djangocon.us/", 
-  "slug": "djangocon-2014", 
-  "start_date": "2014-08-30"
+  "slug": "djangocon-2014",
+  "title": "DjangoCon 2014",
+  "description": "DjangoCon US is the main opportunity for djangonauts to come together in\nthe United States. It will consist of two tracks of talks over three\ndays, and will also provide for open sessions, lightning talks, and a\ndevelopment sprint after the conference.\n\nDjangoCon US provides a critical opportunity for the community members\nto socialize, share ideas, work together, and plan for continued\nsuccess.\n"
 }

--- a/data/djangocon-2014/videos/a-nice-problem-to-have-django-under-heavy-load.json
+++ b/data/djangocon-2014/videos/a-nice-problem-to-have-django-under-heavy-load.json
@@ -1,25 +1,25 @@
 {
-  "category": "DjangoCon 2014", 
-  "slug": "a-nice-problem-to-have-django-under-heavy-load", 
-  "title": "A Nice Problem to Have: Django Under Heavy Load", 
-  "summary": "\"Don't prematurely optimize. Get your project to v1.0.\" This is a mantra often repeated in the Djangoverse. But what happens after v1.0 launch when your awesome site is being crushed by traffic? Scaling Django under load means finding bottlenecks, leveraging new tools, and customizing code. This talk will show you how it's done.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FOPX/", 
-  "description": "", 
-  "quality_notes": "", 
-  "language": "English", 
-  "copyright_text": "", 
-  "thumbnail_url": "https://i.ytimg.com/vi/gukzap2BU2M/maxresdefault.jpg", 
-  "duration": 2547, 
+  "category": "DjangoCon 2014",
+  "slug": "a-nice-problem-to-have-django-under-heavy-load",
+  "title": "A Nice Problem to Have: Django Under Heavy Load",
+  "summary": "\"Don't prematurely optimize. Get your project to v1.0.\" This is a mantra\noften repeated in the Djangoverse. But what happens after v1.0 launch\nwhen your awesome site is being crushed by traffic? Scaling Django under\nload means finding bottlenecks, leveraging new tools, and customizing\ncode. This talk will show you how it's done.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FOPX/\n",
+  "description": "",
+  "quality_notes": "",
+  "language": "English",
+  "copyright_text": "",
+  "thumbnail_url": "https://i.ytimg.com/vi/gukzap2BU2M/maxresdefault.jpg",
+  "duration": 2547,
   "videos": [
     {
-      "url": "https://www.youtube.com/watch?v=gukzap2BU2M", 
-      "length": 0, 
+      "url": "https://www.youtube.com/watch?v=gukzap2BU2M",
+      "length": 0,
       "type": "youtube"
     }
-  ], 
-  "source_url": "https://www.youtube.com/watch?v=gukzap2BU2M", 
-  "tags": [], 
+  ],
+  "source_url": "https://www.youtube.com/watch?v=gukzap2BU2M",
+  "tags": [],
   "speakers": [
     "Joshua \"jag\" Ginsberg"
-  ], 
+  ],
   "recorded": "2014-09-16"
 }

--- a/data/djangocon-2014/videos/activating-your-site-a-look-at-activity-streams.json
+++ b/data/djangocon-2014/videos/activating-your-site-a-look-at-activity-streams.json
@@ -1,27 +1,27 @@
 {
-  "category": "DjangoCon 2014", 
-  "slug": "activating-your-site-a-look-at-activity-streams", 
-  "title": "Activating Your Site: A Look at Activity Streams", 
-  "summary": "We will walk you through how to implement activity streams for your website in a generic fashion by leveraging the activitystrea.ms open specification. The two tools we will show are django-activity-streams which lets you interrelate the objects in your Django site using a supported DB and the activitystreams project which provides a ReST service based on the spec, with Neo4j graph for storage.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FPWj/", 
-  "description": "", 
-  "quality_notes": "", 
-  "language": "English", 
-  "copyright_text": "", 
-  "thumbnail_url": "https://i.ytimg.com/vi/R_tyN8bNe4A/maxresdefault.jpg", 
-  "duration": 2172, 
+  "category": "DjangoCon 2014",
+  "slug": "activating-your-site-a-look-at-activity-streams",
+  "title": "Activating Your Site: A Look at Activity Streams",
+  "summary": "We will walk you through how to implement activity streams for your\nwebsite in a generic fashion by leveraging the activitystrea.ms open\nspecification. The two tools we will show are django-activity-streams\nwhich lets you interrelate the objects in your Django site using a\nsupported DB and the activitystreams project which provides a ReST\nservice based on the spec, with Neo4j graph for storage.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FPWj/\n",
+  "description": "",
+  "quality_notes": "",
+  "language": "English",
+  "copyright_text": "",
+  "thumbnail_url": "https://i.ytimg.com/vi/R_tyN8bNe4A/maxresdefault.jpg",
+  "duration": 2172,
   "videos": [
     {
-      "url": "https://www.youtube.com/watch?v=R_tyN8bNe4A", 
-      "length": 0, 
+      "url": "https://www.youtube.com/watch?v=R_tyN8bNe4A",
+      "length": 0,
       "type": "youtube"
     }
-  ], 
-  "source_url": "https://www.youtube.com/watch?v=R_tyN8bNe4A", 
-  "tags": [], 
+  ],
+  "source_url": "https://www.youtube.com/watch?v=R_tyN8bNe4A",
+  "tags": [],
   "speakers": [
-    "Justin Quick", 
-    "Ben Fonarov", 
+    "Justin Quick",
+    "Ben Fonarov",
     "Farhan Syed"
-  ], 
+  ],
   "recorded": "2014-09-19"
 }

--- a/data/djangocon-2014/videos/all-you-need-is-l.json
+++ b/data/djangocon-2014/videos/all-you-need-is-l.json
@@ -1,25 +1,25 @@
 {
-  "category": "DjangoCon 2014", 
-  "slug": "all-you-need-is-l", 
-  "title": "All You Need Is L***", 
-  "summary": "Help us caption & translate this video!\n\nhttp://amara.org/v/FNEd/", 
-  "description": "", 
-  "quality_notes": "", 
-  "language": "English", 
-  "copyright_text": "", 
-  "thumbnail_url": "https://i.ytimg.com/vi/0mACXAmaL1M/maxresdefault.jpg", 
-  "duration": 3225, 
+  "category": "DjangoCon 2014",
+  "slug": "all-you-need-is-l",
+  "title": "All You Need Is L***",
+  "summary": "Help us caption & translate this video!\n\nhttp://amara.org/v/FNEd/\n",
+  "description": "",
+  "quality_notes": "",
+  "language": "English",
+  "copyright_text": "",
+  "thumbnail_url": "https://i.ytimg.com/vi/0mACXAmaL1M/maxresdefault.jpg",
+  "duration": 3225,
   "videos": [
     {
-      "url": "https://www.youtube.com/watch?v=0mACXAmaL1M", 
-      "length": 0, 
+      "url": "https://www.youtube.com/watch?v=0mACXAmaL1M",
+      "length": 0,
       "type": "youtube"
     }
-  ], 
-  "source_url": "https://www.youtube.com/watch?v=0mACXAmaL1M", 
-  "tags": [], 
+  ],
+  "source_url": "https://www.youtube.com/watch?v=0mACXAmaL1M",
+  "tags": [],
   "speakers": [
     "Daniele Procida"
-  ], 
+  ],
   "recorded": "2014-09-11"
 }

--- a/data/djangocon-2014/videos/anatomy-of-a-django-project.json
+++ b/data/djangocon-2014/videos/anatomy-of-a-django-project.json
@@ -1,25 +1,25 @@
 {
-  "category": "DjangoCon 2014", 
-  "slug": "anatomy-of-a-django-project", 
-  "title": "Anatomy of a Django Project", 
-  "summary": "Websites built with Django are built on \"projects\" which are composed of oneor more \"apps\". But what is a project really? This talk will dissect a Django project to understand which pieces are convention and which are required. It explain what if anything separates a project from an app and answer common questions about projects vs apps.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FNEk/", 
-  "description": "", 
-  "quality_notes": "", 
-  "language": "English", 
-  "copyright_text": "", 
-  "thumbnail_url": "https://i.ytimg.com/vi/ajEDo1semzs/maxresdefault.jpg", 
-  "duration": 1290, 
+  "category": "DjangoCon 2014",
+  "slug": "anatomy-of-a-django-project",
+  "title": "Anatomy of a Django Project",
+  "summary": "Websites built with Django are built on \"projects\" which are composed of\noneor more \"apps\". But what is a project really? This talk will dissect\na Django project to understand which pieces are convention and which are\nrequired. It explain what if anything separates a project from an app\nand answer common questions about projects vs apps.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FNEk/\n",
+  "description": "",
+  "quality_notes": "",
+  "language": "English",
+  "copyright_text": "",
+  "thumbnail_url": "https://i.ytimg.com/vi/ajEDo1semzs/maxresdefault.jpg",
+  "duration": 1290,
   "videos": [
     {
-      "url": "https://www.youtube.com/watch?v=ajEDo1semzs", 
-      "length": 0, 
+      "url": "https://www.youtube.com/watch?v=ajEDo1semzs",
+      "length": 0,
       "type": "youtube"
     }
-  ], 
-  "source_url": "https://www.youtube.com/watch?v=ajEDo1semzs", 
-  "tags": [], 
+  ],
+  "source_url": "https://www.youtube.com/watch?v=ajEDo1semzs",
+  "tags": [],
   "speakers": [
     "Mark Lavin"
-  ], 
+  ],
   "recorded": "2014-09-12"
 }

--- a/data/djangocon-2014/videos/angularjs-django-a-perfect-match.json
+++ b/data/djangocon-2014/videos/angularjs-django-a-perfect-match.json
@@ -1,23 +1,23 @@
 {
-  "category": "DjangoCon 2014", 
-  "slug": "angularjs-django-a-perfect-match", 
-  "title": "AngularJS + Django = A Perfect Match", 
-  "summary": "AngularJS is a powerful MVC framework that can easily integrate with Django templates.\n\nLet's walk through integrating the two for fantastic results. The result is a fast, dynamic single page application.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FOP2/", 
-  "description": "", 
-  "quality_notes": "", 
-  "language": "English", 
-  "copyright_text": "", 
-  "thumbnail_url": "https://i.ytimg.com/vi/vWJorwEQWLk/maxresdefault.jpg", 
-  "duration": 1893, 
+  "category": "DjangoCon 2014",
+  "slug": "angularjs-django-a-perfect-match",
+  "title": "AngularJS + Django = A Perfect Match",
+  "summary": "AngularJS is a powerful MVC framework that can easily integrate with\nDjango templates.\n\nLet's walk through integrating the two for fantastic results. The result\nis a fast, dynamic single page application.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FOP2/\n",
+  "description": "",
+  "quality_notes": "",
+  "language": "English",
+  "copyright_text": "",
+  "thumbnail_url": "https://i.ytimg.com/vi/vWJorwEQWLk/maxresdefault.jpg",
+  "duration": 1893,
   "videos": [
     {
-      "url": "https://www.youtube.com/watch?v=vWJorwEQWLk", 
-      "length": 0, 
+      "url": "https://www.youtube.com/watch?v=vWJorwEQWLk",
+      "length": 0,
       "type": "youtube"
     }
-  ], 
-  "source_url": "https://www.youtube.com/watch?v=vWJorwEQWLk", 
-  "tags": [], 
-  "speakers": [], 
+  ],
+  "source_url": "https://www.youtube.com/watch?v=vWJorwEQWLk",
+  "tags": [],
+  "speakers": [],
   "recorded": "2014-09-17"
 }

--- a/data/djangocon-2014/videos/angularjs-django-a-perfect-match.json
+++ b/data/djangocon-2014/videos/angularjs-django-a-perfect-match.json
@@ -18,6 +18,8 @@
   ],
   "source_url": "https://www.youtube.com/watch?v=vWJorwEQWLk",
   "tags": [],
-  "speakers": [],
+  "speakers": [
+    "Nina Zakharenko"
+  ],
   "recorded": "2014-09-17"
 }

--- a/data/djangocon-2014/videos/brazil-how-we-are-gaining-space-with-django.json
+++ b/data/djangocon-2014/videos/brazil-how-we-are-gaining-space-with-django.json
@@ -1,25 +1,25 @@
 {
-  "category": "DjangoCon 2014", 
-  "slug": "brazil-how-we-are-gaining-space-with-django", 
-  "title": "Brazil: How we are gaining space with Django", 
-  "summary": "It is not uncommon for important django applications to be developed or used by the American or European universities, however this is not the case of Brazil. It is very common for Brazilian universities to rely on PHP or Java frameworks. This talk aims to show how we are turning Django into a viable solution for the development of software in the academia.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FNEs/", 
-  "description": "", 
-  "quality_notes": "", 
-  "language": "English", 
-  "copyright_text": "", 
-  "thumbnail_url": "https://i.ytimg.com/vi/wr_NZr554y4/maxresdefault.jpg", 
-  "duration": 936, 
+  "category": "DjangoCon 2014",
+  "slug": "brazil-how-we-are-gaining-space-with-django",
+  "title": "Brazil: How we are gaining space with Django",
+  "summary": "It is not uncommon for important django applications to be developed or\nused by the American or European universities, however this is not the\ncase of Brazil. It is very common for Brazilian universities to rely on\nPHP or Java frameworks. This talk aims to show how we are turning Django\ninto a viable solution for the development of software in the academia.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FNEs/\n",
+  "description": "",
+  "quality_notes": "",
+  "language": "English",
+  "copyright_text": "",
+  "thumbnail_url": "https://i.ytimg.com/vi/wr_NZr554y4/maxresdefault.jpg",
+  "duration": 936,
   "videos": [
     {
-      "url": "https://www.youtube.com/watch?v=wr_NZr554y4", 
-      "length": 0, 
+      "url": "https://www.youtube.com/watch?v=wr_NZr554y4",
+      "length": 0,
       "type": "youtube"
     }
-  ], 
-  "source_url": "https://www.youtube.com/watch?v=wr_NZr554y4", 
-  "tags": [], 
+  ],
+  "source_url": "https://www.youtube.com/watch?v=wr_NZr554y4",
+  "tags": [],
   "speakers": [
     "Henrique Pereira"
-  ], 
+  ],
   "recorded": "2014-09-13"
 }

--- a/data/djangocon-2014/videos/building-a-rest-api-with-django-django-rest.json
+++ b/data/djangocon-2014/videos/building-a-rest-api-with-django-django-rest.json
@@ -1,25 +1,25 @@
 {
-  "category": "DjangoCon 2014", 
-  "slug": "building-a-rest-api-with-django-django-rest", 
-  "title": "Building a REST API with Django & Django REST Framework", 
-  "summary": "REST APIs are capable of providing valuable services within and beyond an organization. Django and the Django REST Framework enabled my team to quickly deliverable a highly functional REST API that was customized to our unique needs. This discussion will cover how easy Django makes it to build such an application and how to overcome potential pitfalls.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FOP6/", 
-  "description": "", 
-  "quality_notes": "", 
-  "language": "English", 
-  "copyright_text": "", 
-  "thumbnail_url": "https://i.ytimg.com/vi/IcZoasMX5Yo/maxresdefault.jpg", 
-  "duration": 1642, 
+  "category": "DjangoCon 2014",
+  "slug": "building-a-rest-api-with-django-django-rest",
+  "title": "Building a REST API with Django & Django REST Framework",
+  "summary": "REST APIs are capable of providing valuable services within and beyond\nan organization. Django and the Django REST Framework enabled my team to\nquickly deliverable a highly functional REST API that was customized to\nour unique needs. This discussion will cover how easy Django makes it to\nbuild such an application and how to overcome potential pitfalls.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FOP6/\n",
+  "description": "",
+  "quality_notes": "",
+  "language": "English",
+  "copyright_text": "",
+  "thumbnail_url": "https://i.ytimg.com/vi/IcZoasMX5Yo/maxresdefault.jpg",
+  "duration": 1642,
   "videos": [
     {
-      "url": "https://www.youtube.com/watch?v=IcZoasMX5Yo", 
-      "length": 0, 
+      "url": "https://www.youtube.com/watch?v=IcZoasMX5Yo",
+      "length": 0,
       "type": "youtube"
     }
-  ], 
-  "source_url": "https://www.youtube.com/watch?v=IcZoasMX5Yo", 
-  "tags": [], 
+  ],
+  "source_url": "https://www.youtube.com/watch?v=IcZoasMX5Yo",
+  "tags": [],
   "speakers": [
     "Kenny Yarboro"
-  ], 
+  ],
   "recorded": "2014-09-17"
 }

--- a/data/djangocon-2014/videos/choose-your-own-django-deployment-adventure.json
+++ b/data/djangocon-2014/videos/choose-your-own-django-deployment-adventure.json
@@ -2,7 +2,7 @@
   "category": "DjangoCon 2014",
   "slug": "choose-your-own-django-deployment-adventure",
   "title": "Choose Your Own Django Deployment Adventure",
-  "summary": "From WSGI servers and reverse proxies to continuous integration and automated configuration management, the Django deployment environment is a complicated collection of tools for developers new to the framework. This talk explains the most confusing Django deployment topics as chosen by the audience in real-time via text message votes. Bring your phone to participate!\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FPWh/",
+  "summary": "From WSGI servers and reverse proxies to continuous integration and\nautomated configuration management, the Django deployment environment is\na complicated collection of tools for developers new to the framework.\nThis talk explains the most confusing Django deployment topics as chosen\nby the audience in real-time via text message votes. Bring your phone to\nparticipate!\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FPWh/\n",
   "description": "",
   "quality_notes": "",
   "language": "English",

--- a/data/djangocon-2014/videos/class-based-views-past-present-and-future.json
+++ b/data/djangocon-2014/videos/class-based-views-past-present-and-future.json
@@ -1,25 +1,25 @@
 {
-  "category": "DjangoCon 2014", 
-  "slug": "class-based-views-past-present-and-future", 
-  "title": "Class-based Views: Past, Present and Future", 
-  "summary": "One of the big changes in Django 1.3 was the introduction of Class-Based Views. Opinion on them is strongly divided; some love them, some hate them.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FNEo/", 
-  "description": "", 
-  "quality_notes": "", 
-  "language": "English", 
-  "copyright_text": "", 
-  "thumbnail_url": "https://i.ytimg.com/vi/8_x6qLfZjjs/maxresdefault.jpg", 
-  "duration": 2376, 
+  "category": "DjangoCon 2014",
+  "slug": "class-based-views-past-present-and-future",
+  "title": "Class-based Views: Past, Present and Future",
+  "summary": "One of the big changes in Django 1.3 was the introduction of Class-Based\nViews. Opinion on them is strongly divided; some love them, some hate\nthem.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FNEo/\n",
+  "description": "",
+  "quality_notes": "",
+  "language": "English",
+  "copyright_text": "",
+  "thumbnail_url": "https://i.ytimg.com/vi/8_x6qLfZjjs/maxresdefault.jpg",
+  "duration": 2376,
   "videos": [
     {
-      "url": "https://www.youtube.com/watch?v=8_x6qLfZjjs", 
-      "length": 0, 
+      "url": "https://www.youtube.com/watch?v=8_x6qLfZjjs",
+      "length": 0,
       "type": "youtube"
     }
-  ], 
-  "source_url": "https://www.youtube.com/watch?v=8_x6qLfZjjs", 
-  "tags": [], 
+  ],
+  "source_url": "https://www.youtube.com/watch?v=8_x6qLfZjjs",
+  "tags": [],
   "speakers": [
     "Russell Keith-Magee"
-  ], 
+  ],
   "recorded": "2014-09-13"
 }

--- a/data/djangocon-2014/videos/connecting-patients-to-doctors-in-real-time-using.json
+++ b/data/djangocon-2014/videos/connecting-patients-to-doctors-in-real-time-using.json
@@ -1,25 +1,25 @@
 {
-  "category": "DjangoCon 2014", 
-  "slug": "connecting-patients-to-doctors-in-real-time-using", 
-  "title": "Connecting Patients to Doctors in Real-Time Using Django", 
-  "summary": "Your challenge, should you choose to accept it, is to create a system that allows patients to connect to doctors licensed in their state efficiently. How I used Django, Celery, Redis and Websockets to create a real-time matching system for Doctor On Demand.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FNEr/", 
-  "description": "", 
-  "quality_notes": "", 
-  "language": "English", 
-  "copyright_text": "", 
-  "thumbnail_url": "https://i.ytimg.com/vi/txlURM0n41Q/maxresdefault.jpg", 
-  "duration": 1277, 
+  "category": "DjangoCon 2014",
+  "slug": "connecting-patients-to-doctors-in-real-time-using",
+  "title": "Connecting Patients to Doctors in Real-Time Using Django",
+  "summary": "Your challenge, should you choose to accept it, is to create a system\nthat allows patients to connect to doctors licensed in their state\nefficiently. How I used Django, Celery, Redis and Websockets to create a\nreal-time matching system for Doctor On Demand.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FNEr/\n",
+  "description": "",
+  "quality_notes": "",
+  "language": "English",
+  "copyright_text": "",
+  "thumbnail_url": "https://i.ytimg.com/vi/txlURM0n41Q/maxresdefault.jpg",
+  "duration": 1277,
   "videos": [
     {
-      "url": "https://www.youtube.com/watch?v=txlURM0n41Q", 
-      "length": 0, 
+      "url": "https://www.youtube.com/watch?v=txlURM0n41Q",
+      "length": 0,
       "type": "youtube"
     }
-  ], 
-  "source_url": "https://www.youtube.com/watch?v=txlURM0n41Q", 
-  "tags": [], 
+  ],
+  "source_url": "https://www.youtube.com/watch?v=txlURM0n41Q",
+  "tags": [],
   "speakers": [
     "Jacinda Shelly"
-  ], 
+  ],
   "recorded": "2014-09-13"
 }

--- a/data/djangocon-2014/videos/development-with-ansible-and-vms.json
+++ b/data/djangocon-2014/videos/development-with-ansible-and-vms.json
@@ -1,25 +1,25 @@
 {
-  "category": "DjangoCon 2014", 
-  "slug": "development-with-ansible-and-vms", 
-  "title": "Development with Ansible and VMs", 
-  "summary": "How do you set up a kick-ass dev environment? I'll share our team's setup and tools that give us a dev environment with superpowers: mirrors production; sets itself up with a single command; documented in code; repeatable and shareable. I hope you learn something you can put into action tomorrow!\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FNEf/", 
-  "description": "", 
-  "quality_notes": "", 
-  "language": "English", 
-  "copyright_text": "", 
-  "thumbnail_url": "https://i.ytimg.com/vi/Lr6Vr4A_Q5Y/maxresdefault.jpg", 
-  "duration": 1577, 
+  "category": "DjangoCon 2014",
+  "slug": "development-with-ansible-and-vms",
+  "title": "Development with Ansible and VMs",
+  "summary": "How do you set up a kick-ass dev environment? I'll share our team's\nsetup and tools that give us a dev environment with superpowers: mirrors\nproduction; sets itself up with a single command; documented in code;\nrepeatable and shareable. I hope you learn something you can put into\naction tomorrow!\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FNEf/\n",
+  "description": "",
+  "quality_notes": "",
+  "language": "English",
+  "copyright_text": "",
+  "thumbnail_url": "https://i.ytimg.com/vi/Lr6Vr4A_Q5Y/maxresdefault.jpg",
+  "duration": 1577,
   "videos": [
     {
-      "url": "https://www.youtube.com/watch?v=Lr6Vr4A_Q5Y", 
-      "length": 0, 
+      "url": "https://www.youtube.com/watch?v=Lr6Vr4A_Q5Y",
+      "length": 0,
       "type": "youtube"
     }
-  ], 
-  "source_url": "https://www.youtube.com/watch?v=Lr6Vr4A_Q5Y", 
-  "tags": [], 
+  ],
+  "source_url": "https://www.youtube.com/watch?v=Lr6Vr4A_Q5Y",
+  "tags": [],
   "speakers": [
     "Jeff Schenck"
-  ], 
+  ],
   "recorded": "2014-09-11"
 }

--- a/data/djangocon-2014/videos/digging-into-djangos-migrations.json
+++ b/data/djangocon-2014/videos/digging-into-djangos-migrations.json
@@ -1,25 +1,25 @@
 {
-  "category": "DjangoCon 2014", 
-  "slug": "digging-into-djangos-migrations", 
-  "title": "Digging Into Django's Migrations", 
-  "summary": "An in-depth look at Django's new migrations framework, explaining the component architecture, highlighting issues with multiple database backends, and showing how management commands typically get routed through the software.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FOPT/", 
-  "description": "", 
-  "quality_notes": "", 
-  "language": "English", 
-  "copyright_text": "", 
-  "thumbnail_url": "https://i.ytimg.com/vi/lIY_3vL39j8/maxresdefault.jpg", 
-  "duration": 2589, 
+  "category": "DjangoCon 2014",
+  "slug": "digging-into-djangos-migrations",
+  "title": "Digging Into Django's Migrations",
+  "summary": "An in-depth look at Django's new migrations framework, explaining the\ncomponent architecture, highlighting issues with multiple database\nbackends, and showing how management commands typically get routed\nthrough the software.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FOPT/\n",
+  "description": "",
+  "quality_notes": "",
+  "language": "English",
+  "copyright_text": "",
+  "thumbnail_url": "https://i.ytimg.com/vi/lIY_3vL39j8/maxresdefault.jpg",
+  "duration": 2589,
   "videos": [
     {
-      "url": "https://www.youtube.com/watch?v=lIY_3vL39j8", 
-      "length": 0, 
+      "url": "https://www.youtube.com/watch?v=lIY_3vL39j8",
+      "length": 0,
       "type": "youtube"
     }
-  ], 
-  "source_url": "https://www.youtube.com/watch?v=lIY_3vL39j8", 
-  "tags": [], 
+  ],
+  "source_url": "https://www.youtube.com/watch?v=lIY_3vL39j8",
+  "tags": [],
   "speakers": [
     "Andrew Godwin"
-  ], 
+  ],
   "recorded": "2014-09-16"
 }

--- a/data/djangocon-2014/videos/django-a-data-shovel-with-a-future.json
+++ b/data/djangocon-2014/videos/django-a-data-shovel-with-a-future.json
@@ -1,25 +1,25 @@
 {
-  "category": "DjangoCon 2014", 
-  "slug": "django-a-data-shovel-with-a-future", 
-  "title": "Django: a Data Shovel With a Future", 
-  "summary": "Help us caption & translate this video!\n\nhttp://amara.org/v/FPWf/", 
-  "description": "", 
-  "quality_notes": "", 
-  "language": "English", 
-  "copyright_text": "", 
-  "thumbnail_url": "https://i.ytimg.com/vi/Z_pJxBxR5ec/maxresdefault.jpg", 
-  "duration": 3189, 
+  "category": "DjangoCon 2014",
+  "slug": "django-a-data-shovel-with-a-future",
+  "title": "Django: a Data Shovel With a Future",
+  "summary": "Help us caption & translate this video!\n\nhttp://amara.org/v/FPWf/\n",
+  "description": "",
+  "quality_notes": "",
+  "language": "English",
+  "copyright_text": "",
+  "thumbnail_url": "https://i.ytimg.com/vi/Z_pJxBxR5ec/maxresdefault.jpg",
+  "duration": 3189,
   "videos": [
     {
-      "url": "https://www.youtube.com/watch?v=Z_pJxBxR5ec", 
-      "length": 0, 
+      "url": "https://www.youtube.com/watch?v=Z_pJxBxR5ec",
+      "length": 0,
       "type": "youtube"
     }
-  ], 
-  "source_url": "https://www.youtube.com/watch?v=Z_pJxBxR5ec", 
-  "tags": [], 
+  ],
+  "source_url": "https://www.youtube.com/watch?v=Z_pJxBxR5ec",
+  "tags": [],
   "speakers": [
     "Brandon Rhodes"
-  ], 
+  ],
   "recorded": "2014-09-19"
 }

--- a/data/djangocon-2014/videos/django-rest-api-so-easy-you-can-learn-it-in-25.json
+++ b/data/djangocon-2014/videos/django-rest-api-so-easy-you-can-learn-it-in-25.json
@@ -1,25 +1,25 @@
 {
-  "category": "DjangoCon 2014", 
-  "slug": "django-rest-api-so-easy-you-can-learn-it-in-25", 
-  "title": "Django REST API - So easy you can learn it in 25 minutes", 
-  "summary": "Django REST Framework can make creating a RESTFUL api quick and easy.\n\nJoin me as I go over: - What makes an API Restful - How Serializers can make representing your existing models in JSON a breeze - What the built in Views provide for you, and how to provide authentication for your API - How to route to your new Endpoints - Last but not least, how to Unit Test them\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FNEj/", 
-  "description": "", 
-  "quality_notes": "", 
-  "language": "English", 
-  "copyright_text": "", 
-  "thumbnail_url": "https://i.ytimg.com/vi/cqP758k1BaQ/maxresdefault.jpg", 
-  "duration": 1408, 
+  "category": "DjangoCon 2014",
+  "slug": "django-rest-api-so-easy-you-can-learn-it-in-25",
+  "title": "Django REST API - So easy you can learn it in 25 minutes",
+  "summary": "Django REST Framework can make creating a RESTFUL api quick and easy.\n\nJoin me as I go over: - What makes an API Restful - How Serializers can\nmake representing your existing models in JSON a breeze - What the built\nin Views provide for you, and how to provide authentication for your API\n- How to route to your new Endpoints - Last but not least, how to Unit\nTest them\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FNEj/\n",
+  "description": "",
+  "quality_notes": "",
+  "language": "English",
+  "copyright_text": "",
+  "thumbnail_url": "https://i.ytimg.com/vi/cqP758k1BaQ/maxresdefault.jpg",
+  "duration": 1408,
   "videos": [
     {
-      "url": "https://www.youtube.com/watch?v=cqP758k1BaQ", 
-      "length": 0, 
+      "url": "https://www.youtube.com/watch?v=cqP758k1BaQ",
+      "length": 0,
       "type": "youtube"
     }
-  ], 
-  "source_url": "https://www.youtube.com/watch?v=cqP758k1BaQ", 
-  "tags": [], 
+  ],
+  "source_url": "https://www.youtube.com/watch?v=cqP758k1BaQ",
+  "tags": [],
   "speakers": [
     "Nina Zakharenko"
-  ], 
+  ],
   "recorded": "2014-09-12"
 }

--- a/data/djangocon-2014/videos/do-you-wanna-be-a-core-dev-you-dont-have-to-be-dev.json
+++ b/data/djangocon-2014/videos/do-you-wanna-be-a-core-dev-you-dont-have-to-be-dev.json
@@ -1,25 +1,25 @@
 {
-  "category": "DjangoCon 2014", 
-  "slug": "do-you-wanna-be-a-core-dev-you-dont-have-to-be-dev", 
-  "title": "Do you wanna be a core dev? (You don't have to be core dev...)", 
-  "summary": "The most important part of Django is it's community of contributors -- without contributors, Django would never improve. However, while it's relatively easy to work out how to use Django, the process of getting involved in development is a little more opaque. How does the the core team operate? What tools and decision making processes exist? And how do you, as a Django user, get involved?\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FOPV/", 
-  "description": "", 
-  "quality_notes": "", 
-  "language": "English", 
-  "copyright_text": "", 
-  "thumbnail_url": "https://i.ytimg.com/vi/miHGABXNo-s/hqdefault.jpg", 
-  "duration": 2915, 
+  "category": "DjangoCon 2014",
+  "slug": "do-you-wanna-be-a-core-dev-you-dont-have-to-be-dev",
+  "title": "Do you wanna be a core dev? (You don't have to be core dev...)",
+  "summary": "The most important part of Django is it's community of contributors --\nwithout contributors, Django would never improve. However, while it's\nrelatively easy to work out how to use Django, the process of getting\ninvolved in development is a little more opaque. How does the the core\nteam operate? What tools and decision making processes exist? And how do\nyou, as a Django user, get involved?\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FOPV/\n",
+  "description": "",
+  "quality_notes": "",
+  "language": "English",
+  "copyright_text": "",
+  "thumbnail_url": "https://i.ytimg.com/vi/miHGABXNo-s/hqdefault.jpg",
+  "duration": 2915,
   "videos": [
     {
-      "url": "https://www.youtube.com/watch?v=miHGABXNo-s", 
-      "length": 0, 
+      "url": "https://www.youtube.com/watch?v=miHGABXNo-s",
+      "length": 0,
       "type": "youtube"
     }
-  ], 
-  "source_url": "https://www.youtube.com/watch?v=miHGABXNo-s", 
-  "tags": [], 
+  ],
+  "source_url": "https://www.youtube.com/watch?v=miHGABXNo-s",
+  "tags": [],
   "speakers": [
     "Russell Keith-Magee"
-  ], 
+  ],
   "recorded": "2014-09-16"
 }

--- a/data/djangocon-2014/videos/elasticsearch-dsl.json
+++ b/data/djangocon-2014/videos/elasticsearch-dsl.json
@@ -1,25 +1,25 @@
 {
-  "category": "DjangoCon 2014", 
-  "slug": "elasticsearch-dsl", 
-  "title": "Elasticsearch DSL", 
-  "summary": "Elasticsearch DSL is a new library for integrating Django apps with Elasticsearch, enabling users to utilize the full power of Elasticsearch.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FOP7/", 
-  "description": "", 
-  "quality_notes": "", 
-  "language": "English", 
-  "copyright_text": "", 
-  "thumbnail_url": "https://i.ytimg.com/vi/hE359wuHyhs/maxresdefault.jpg", 
-  "duration": 2532, 
+  "category": "DjangoCon 2014",
+  "slug": "elasticsearch-dsl",
+  "title": "Elasticsearch DSL",
+  "summary": "Elasticsearch DSL is a new library for integrating Django apps with\nElasticsearch, enabling users to utilize the full power of\nElasticsearch.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FOP7/\n",
+  "description": "",
+  "quality_notes": "",
+  "language": "English",
+  "copyright_text": "",
+  "thumbnail_url": "https://i.ytimg.com/vi/hE359wuHyhs/maxresdefault.jpg",
+  "duration": 2532,
   "videos": [
     {
-      "url": "https://www.youtube.com/watch?v=hE359wuHyhs", 
-      "length": 0, 
+      "url": "https://www.youtube.com/watch?v=hE359wuHyhs",
+      "length": 0,
       "type": "youtube"
     }
-  ], 
-  "source_url": "https://www.youtube.com/watch?v=hE359wuHyhs", 
-  "tags": [], 
+  ],
+  "source_url": "https://www.youtube.com/watch?v=hE359wuHyhs",
+  "tags": [],
   "speakers": [
     "Honza Kr\u00e1l"
-  ], 
+  ],
   "recorded": "2014-09-17"
 }

--- a/data/djangocon-2014/videos/from-icontains-to-search.json
+++ b/data/djangocon-2014/videos/from-icontains-to-search.json
@@ -1,25 +1,25 @@
 {
-  "category": "DjangoCon 2014", 
-  "slug": "from-icontains-to-search", 
-  "title": "From __icontains to search", 
-  "summary": "Good search experience for your users is about more than just a more efficient way to find models containing certain word or phrase. In this talk we'll go through what are the relevant parts of search and how to best implement them (we'll use Elasticsearch for actual examples).\n\nThe goal of the talk is to demystify search engines and provide the attendees with the tools required to create a great search experience for their sites. It will cover basics from information retrieval theory as well as practical examples on how to integrate search into their apps.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FNEn/", 
-  "description": "", 
-  "quality_notes": "", 
-  "language": "English", 
-  "copyright_text": "", 
-  "thumbnail_url": "https://i.ytimg.com/vi/Dz1hATSSSiQ/maxresdefault.jpg", 
-  "duration": 1535, 
+  "category": "DjangoCon 2014",
+  "slug": "from-icontains-to-search",
+  "title": "From __icontains to search",
+  "summary": "Good search experience for your users is about more than just a more\nefficient way to find models containing certain word or phrase. In this\ntalk we'll go through what are the relevant parts of search and how to\nbest implement them (we'll use Elasticsearch for actual examples).\n\nThe goal of the talk is to demystify search engines and provide the\nattendees with the tools required to create a great search experience\nfor their sites. It will cover basics from information retrieval theory\nas well as practical examples on how to integrate search into their\napps.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FNEn/\n",
+  "description": "",
+  "quality_notes": "",
+  "language": "English",
+  "copyright_text": "",
+  "thumbnail_url": "https://i.ytimg.com/vi/Dz1hATSSSiQ/maxresdefault.jpg",
+  "duration": 1535,
   "videos": [
     {
-      "url": "https://www.youtube.com/watch?v=Dz1hATSSSiQ", 
-      "length": 0, 
+      "url": "https://www.youtube.com/watch?v=Dz1hATSSSiQ",
+      "length": 0,
       "type": "youtube"
     }
-  ], 
-  "source_url": "https://www.youtube.com/watch?v=Dz1hATSSSiQ", 
-  "tags": [], 
+  ],
+  "source_url": "https://www.youtube.com/watch?v=Dz1hATSSSiQ",
+  "tags": [],
   "speakers": [
     "Honza Kr\u00e1l"
-  ], 
+  ],
   "recorded": "2014-09-13"
 }

--- a/data/djangocon-2014/videos/from-legacy-to-admin.json
+++ b/data/djangocon-2014/videos/from-legacy-to-admin.json
@@ -1,25 +1,25 @@
 {
-  "category": "DjangoCon 2014", 
-  "slug": "from-legacy-to-admin", 
-  "title": "From Legacy to Admin", 
-  "summary": "For those who have not had the pleasure of seeing django's inspectdb command in action, I will create a demonstration of it's power. Django's inspectdb command can reverse engineer a set of models from a postgres or mysql database. I will demonstrate how to take a legacy database and create a quick and dirty admin tool along with a simple rest interface.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FOP1/", 
-  "description": "", 
-  "quality_notes": "", 
-  "language": "English", 
-  "copyright_text": "", 
-  "thumbnail_url": "https://i.ytimg.com/vi/G_GVBi7oVqA/maxresdefault.jpg", 
-  "duration": 1504, 
+  "category": "DjangoCon 2014",
+  "slug": "from-legacy-to-admin",
+  "title": "From Legacy to Admin",
+  "summary": "For those who have not had the pleasure of seeing django's inspectdb\ncommand in action, I will create a demonstration of it's power. Django's\ninspectdb command can reverse engineer a set of models from a postgres\nor mysql database. I will demonstrate how to take a legacy database and\ncreate a quick and dirty admin tool along with a simple rest interface.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FOP1/\n",
+  "description": "",
+  "quality_notes": "",
+  "language": "English",
+  "copyright_text": "",
+  "thumbnail_url": "https://i.ytimg.com/vi/G_GVBi7oVqA/maxresdefault.jpg",
+  "duration": 1504,
   "videos": [
     {
-      "url": "https://www.youtube.com/watch?v=G_GVBi7oVqA", 
-      "length": 0, 
+      "url": "https://www.youtube.com/watch?v=G_GVBi7oVqA",
+      "length": 0,
       "type": "youtube"
     }
-  ], 
-  "source_url": "https://www.youtube.com/watch?v=G_GVBi7oVqA", 
-  "tags": [], 
+  ],
+  "source_url": "https://www.youtube.com/watch?v=G_GVBi7oVqA",
+  "tags": [],
   "speakers": [
     "Chris Cabral"
-  ], 
+  ],
   "recorded": "2014-09-17"
 }

--- a/data/djangocon-2014/videos/geo-django-geo-beyond-the-django.json
+++ b/data/djangocon-2014/videos/geo-django-geo-beyond-the-django.json
@@ -1,25 +1,25 @@
 {
-  "category": "DjangoCon 2014", 
-  "slug": "geo-django-geo-beyond-the-django", 
-  "title": "Geo+Django: Geo beyond the Django", 
-  "summary": "Have you gone through the comprehensive GeoDjango docs, but wondered where to go next? Are you curious about how you can combine the power GeoDjango with other community-built tools? Do you want to create pretty maps in Python? If so, you are in the right place. Learn about GeoDjango and Geographic Information Systems and navigate beyond the docs into the exciting GIS technology landscape.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FOPU/", 
-  "description": "", 
-  "quality_notes": "", 
-  "language": "English", 
-  "copyright_text": "", 
-  "thumbnail_url": "https://i.ytimg.com/vi/mUhinowr3RY/maxresdefault.jpg", 
-  "duration": 1466, 
+  "category": "DjangoCon 2014",
+  "slug": "geo-django-geo-beyond-the-django",
+  "title": "Geo+Django: Geo beyond the Django",
+  "summary": "Have you gone through the comprehensive GeoDjango docs, but wondered\nwhere to go next? Are you curious about how you can combine the power\nGeoDjango with other community-built tools? Do you want to create pretty\nmaps in Python? If so, you are in the right place. Learn about GeoDjango\nand Geographic Information Systems and navigate beyond the docs into the\nexciting GIS technology landscape.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FOPU/\n",
+  "description": "",
+  "quality_notes": "",
+  "language": "English",
+  "copyright_text": "",
+  "thumbnail_url": "https://i.ytimg.com/vi/mUhinowr3RY/maxresdefault.jpg",
+  "duration": 1466,
   "videos": [
     {
-      "url": "https://www.youtube.com/watch?v=mUhinowr3RY", 
-      "length": 0, 
+      "url": "https://www.youtube.com/watch?v=mUhinowr3RY",
+      "length": 0,
       "type": "youtube"
     }
-  ], 
-  "source_url": "https://www.youtube.com/watch?v=mUhinowr3RY", 
-  "tags": [], 
+  ],
+  "source_url": "https://www.youtube.com/watch?v=mUhinowr3RY",
+  "tags": [],
   "speakers": [
     "Joe Jasinski"
-  ], 
+  ],
   "recorded": "2014-09-16"
 }

--- a/data/djangocon-2014/videos/gnu-mailman-3-and-django.json
+++ b/data/djangocon-2014/videos/gnu-mailman-3-and-django.json
@@ -19,7 +19,7 @@
   "source_url": "https://www.youtube.com/watch?v=m1BTDdzJgcY",
   "tags": [],
   "speakers": [
-    "Florain Fuchs"
+    "Florian Fuchs"
   ],
   "recorded": "2014-09-13"
 }

--- a/data/djangocon-2014/videos/gnu-mailman-3-and-django.json
+++ b/data/djangocon-2014/videos/gnu-mailman-3-and-django.json
@@ -1,25 +1,25 @@
 {
-  "category": "DjangoCon 2014", 
-  "slug": "gnu-mailman-3-and-django", 
-  "title": "GNU Mailman 3 and Django", 
-  "summary": "GNU Mailman, the popular mailing list manager has undergone a major redesign. One of the changes is the separation of the web user interfaces from the core engine and the use of Django for list management and archiving.\n\nThis talk shows how these interfaces use Mailman's internal APIs, how they can be integrated into existing Django projects and how they can be customized and extended.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FNEp/", 
-  "description": "", 
-  "quality_notes": "", 
-  "language": "English", 
-  "copyright_text": "", 
-  "thumbnail_url": "https://i.ytimg.com/vi/m1BTDdzJgcY/maxresdefault.jpg", 
-  "duration": 1374, 
+  "category": "DjangoCon 2014",
+  "slug": "gnu-mailman-3-and-django",
+  "title": "GNU Mailman 3 and Django",
+  "summary": "GNU Mailman, the popular mailing list manager has undergone a major\nredesign. One of the changes is the separation of the web user\ninterfaces from the core engine and the use of Django for list\nmanagement and archiving.\n\nThis talk shows how these interfaces use Mailman's internal APIs, how\nthey can be integrated into existing Django projects and how they can be\ncustomized and extended.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FNEp/\n",
+  "description": "",
+  "quality_notes": "",
+  "language": "English",
+  "copyright_text": "",
+  "thumbnail_url": "https://i.ytimg.com/vi/m1BTDdzJgcY/maxresdefault.jpg",
+  "duration": 1374,
   "videos": [
     {
-      "url": "https://www.youtube.com/watch?v=m1BTDdzJgcY", 
-      "length": 0, 
+      "url": "https://www.youtube.com/watch?v=m1BTDdzJgcY",
+      "length": 0,
       "type": "youtube"
     }
-  ], 
-  "source_url": "https://www.youtube.com/watch?v=m1BTDdzJgcY", 
-  "tags": [], 
+  ],
+  "source_url": "https://www.youtube.com/watch?v=m1BTDdzJgcY",
+  "tags": [],
   "speakers": [
     "Florain Fuchs"
-  ], 
+  ],
   "recorded": "2014-09-13"
 }

--- a/data/djangocon-2014/videos/high-performance-django-from-runserver-to-reddit.json
+++ b/data/djangocon-2014/videos/high-performance-django-from-runserver-to-reddit.json
@@ -1,25 +1,25 @@
 {
-  "category": "DjangoCon 2014", 
-  "slug": "high-performance-django-from-runserver-to-reddit", 
-  "title": "High Performance Django: From Runserver to Reddit Hugs", 
-  "summary": "Django makes it easy to build a site and get it running on your laptop, but how do you go from there to a site that can gracefully handle millions of page views per day? This talk will show you the modifications and supporting services needed to make your site scale. Topics will include caching, uWSGI, Varnish, and load balancing.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FPWi/", 
-  "description": "", 
-  "quality_notes": "", 
-  "language": "English", 
-  "copyright_text": "", 
-  "thumbnail_url": "https://i.ytimg.com/vi/Toa9lW8UMOA/maxresdefault.jpg", 
-  "duration": 2364, 
+  "category": "DjangoCon 2014",
+  "slug": "high-performance-django-from-runserver-to-reddit",
+  "title": "High Performance Django: From Runserver to Reddit Hugs",
+  "summary": "Django makes it easy to build a site and get it running on your laptop,\nbut how do you go from there to a site that can gracefully handle\nmillions of page views per day? This talk will show you the\nmodifications and supporting services needed to make your site scale.\nTopics will include caching, uWSGI, Varnish, and load balancing.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FPWi/\n",
+  "description": "",
+  "quality_notes": "",
+  "language": "English",
+  "copyright_text": "",
+  "thumbnail_url": "https://i.ytimg.com/vi/Toa9lW8UMOA/maxresdefault.jpg",
+  "duration": 2364,
   "videos": [
     {
-      "url": "https://www.youtube.com/watch?v=Toa9lW8UMOA", 
-      "length": 0, 
+      "url": "https://www.youtube.com/watch?v=Toa9lW8UMOA",
+      "length": 0,
       "type": "youtube"
     }
-  ], 
-  "source_url": "https://www.youtube.com/watch?v=Toa9lW8UMOA", 
-  "tags": [], 
+  ],
+  "source_url": "https://www.youtube.com/watch?v=Toa9lW8UMOA",
+  "tags": [],
   "speakers": [
     "Peter Baumgartner"
-  ], 
+  ],
   "recorded": "2014-09-19"
 }

--- a/data/djangocon-2014/videos/how-do-debug-tool-bars-for-web-applications-work.json
+++ b/data/djangocon-2014/videos/how-do-debug-tool-bars-for-web-applications-work.json
@@ -1,25 +1,25 @@
 {
-  "category": "DjangoCon 2014", 
-  "slug": "how-do-debug-tool-bars-for-web-applications-work", 
-  "title": "How do debug tool bars for web applications work?", 
-  "summary": "The Django debug toolbar is for many an indispensable part of the developer toolkit. This talk will look at how such web application debug tool bars are integrated into your web application and are able to inject information into your browser window, how they capture the information presented and how you can extend them.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FNEi/", 
-  "description": "", 
-  "quality_notes": "", 
-  "language": "English", 
-  "copyright_text": "", 
-  "thumbnail_url": "https://i.ytimg.com/vi/QkxWn-GNQAo/maxresdefault.jpg", 
-  "duration": 1628, 
+  "category": "DjangoCon 2014",
+  "slug": "how-do-debug-tool-bars-for-web-applications-work",
+  "title": "How do debug tool bars for web applications work?",
+  "summary": "The Django debug toolbar is for many an indispensable part of the\ndeveloper toolkit. This talk will look at how such web application debug\ntool bars are integrated into your web application and are able to\ninject information into your browser window, how they capture the\ninformation presented and how you can extend them.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FNEi/\n",
+  "description": "",
+  "quality_notes": "",
+  "language": "English",
+  "copyright_text": "",
+  "thumbnail_url": "https://i.ytimg.com/vi/QkxWn-GNQAo/maxresdefault.jpg",
+  "duration": 1628,
   "videos": [
     {
-      "url": "https://www.youtube.com/watch?v=QkxWn-GNQAo", 
-      "length": 0, 
+      "url": "https://www.youtube.com/watch?v=QkxWn-GNQAo",
+      "length": 0,
       "type": "youtube"
     }
-  ], 
-  "source_url": "https://www.youtube.com/watch?v=QkxWn-GNQAo", 
-  "tags": [], 
+  ],
+  "source_url": "https://www.youtube.com/watch?v=QkxWn-GNQAo",
+  "tags": [],
   "speakers": [
     "Graham Dumpleton"
-  ], 
+  ],
   "recorded": "2014-09-12"
 }

--- a/data/djangocon-2014/videos/how-to-build-things-that-matter.json
+++ b/data/djangocon-2014/videos/how-to-build-things-that-matter.json
@@ -1,25 +1,25 @@
 {
-  "category": "DjangoCon 2014", 
-  "slug": "how-to-build-things-that-matter", 
-  "title": "HOW TO BUILD THINGS THAT MATTER", 
-  "summary": "Building software that changes lives is hard work. This talk will focus on three important concepts that you can use to identify problems, solve them, and get feedback on your solutions as soon as possible. The focus will be on why Django matters in this process, and what Django does for you as a creator to speed up this process.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FNEh/", 
-  "description": "", 
-  "quality_notes": "", 
-  "language": "English", 
-  "copyright_text": "", 
-  "thumbnail_url": "https://i.ytimg.com/vi/uaiATfneuPY/maxresdefault.jpg", 
-  "duration": 2559, 
+  "category": "DjangoCon 2014",
+  "slug": "how-to-build-things-that-matter",
+  "title": "HOW TO BUILD THINGS THAT MATTER",
+  "summary": "Building software that changes lives is hard work. This talk will focus\non three important concepts that you can use to identify problems, solve\nthem, and get feedback on your solutions as soon as possible. The focus\nwill be on why Django matters in this process, and what Django does for\nyou as a creator to speed up this process.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FNEh/\n",
+  "description": "",
+  "quality_notes": "",
+  "language": "English",
+  "copyright_text": "",
+  "thumbnail_url": "https://i.ytimg.com/vi/uaiATfneuPY/maxresdefault.jpg",
+  "duration": 2559,
   "videos": [
     {
-      "url": "https://www.youtube.com/watch?v=uaiATfneuPY", 
-      "length": 0, 
+      "url": "https://www.youtube.com/watch?v=uaiATfneuPY",
+      "length": 0,
       "type": "youtube"
     }
-  ], 
-  "source_url": "https://www.youtube.com/watch?v=uaiATfneuPY", 
-  "tags": [], 
+  ],
+  "source_url": "https://www.youtube.com/watch?v=uaiATfneuPY",
+  "tags": [],
   "speakers": [
     "Dave Merwin"
-  ], 
+  ],
   "recorded": "2014-09-12"
 }

--- a/data/djangocon-2014/videos/how-to-solve-djangos-top-5-enterprise-headaches.json
+++ b/data/djangocon-2014/videos/how-to-solve-djangos-top-5-enterprise-headaches.json
@@ -1,25 +1,25 @@
 {
-  "category": "DjangoCon 2014", 
-  "slug": "how-to-solve-djangos-top-5-enterprise-headaches", 
-  "title": "How to Solve Django's Top 5 Enterprise Headaches", 
-  "summary": "The top five Django problems in large enterprise organizations are integrating with Active Directory, passing security audits, transferring data from legacy systems, installing packages from PyPI through proxy servers and combating misperceptions around dynamically typed programming languages. We'll solve these problems with code and resources to back up arguments to enterprise stakeholders.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FOPZ/", 
-  "description": "", 
-  "quality_notes": "", 
-  "language": "English", 
-  "copyright_text": "", 
-  "thumbnail_url": "https://i.ytimg.com/vi/aMtiCX38w20/maxresdefault.jpg", 
-  "duration": 1642, 
+  "category": "DjangoCon 2014",
+  "slug": "how-to-solve-djangos-top-5-enterprise-headaches",
+  "title": "How to Solve Django's Top 5 Enterprise Headaches",
+  "summary": "The top five Django problems in large enterprise organizations are\nintegrating with Active Directory, passing security audits, transferring\ndata from legacy systems, installing packages from PyPI through proxy\nservers and combating misperceptions around dynamically typed\nprogramming languages. We'll solve these problems with code and\nresources to back up arguments to enterprise stakeholders.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FOPZ/\n",
+  "description": "",
+  "quality_notes": "",
+  "language": "English",
+  "copyright_text": "",
+  "thumbnail_url": "https://i.ytimg.com/vi/aMtiCX38w20/maxresdefault.jpg",
+  "duration": 1642,
   "videos": [
     {
-      "url": "https://www.youtube.com/watch?v=aMtiCX38w20", 
-      "length": 0, 
+      "url": "https://www.youtube.com/watch?v=aMtiCX38w20",
+      "length": 0,
       "type": "youtube"
     }
-  ], 
-  "source_url": "https://www.youtube.com/watch?v=aMtiCX38w20", 
-  "tags": [], 
+  ],
+  "source_url": "https://www.youtube.com/watch?v=aMtiCX38w20",
+  "tags": [],
   "speakers": [
     "Matt Makai"
-  ], 
+  ],
   "recorded": "2014-09-16"
 }

--- a/data/djangocon-2014/videos/inheriting-a-sloppy-codebase-a-practical-guide-to.json
+++ b/data/djangocon-2014/videos/inheriting-a-sloppy-codebase-a-practical-guide-to.json
@@ -1,25 +1,25 @@
 {
-  "category": "DjangoCon 2014", 
-  "slug": "inheriting-a-sloppy-codebase-a-practical-guide-to", 
-  "title": "Inheriting a Sloppy Codebase: A Practical Guide to Wrangling Chaotic Code", 
-  "summary": "In an industry where \u201clean\u201d has become the mantra and rapidly iterated products imply tight budgets and tighter deadlines, how do you effectively take ownership of someone\u2019s hastily written Django code? In this talk, we\u2019ll dive into a step-by-step process for dicing up legacy projects, short-sighted prototypes, and plain ol\u2019 spaghetti code to turn them into codebases you\u2019ll show off with pride.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FNEt/", 
-  "description": "", 
-  "quality_notes": "", 
-  "language": "English", 
-  "copyright_text": "", 
-  "thumbnail_url": "https://i.ytimg.com/vi/URztqq1kiqI/maxresdefault.jpg", 
-  "duration": 2524, 
+  "category": "DjangoCon 2014",
+  "slug": "inheriting-a-sloppy-codebase-a-practical-guide-to",
+  "title": "Inheriting a Sloppy Codebase: A Practical Guide to Wrangling Chaotic Code",
+  "summary": "In an industry where \u201clean\u201d has become the mantra and rapidly iterated\nproducts imply tight budgets and tighter deadlines, how do you\neffectively take ownership of someone\u2019s hastily written Django code? In\nthis talk, we\u2019ll dive into a step-by-step process for dicing up legacy\nprojects, short-sighted prototypes, and plain ol\u2019 spaghetti code to turn\nthem into codebases you\u2019ll show off with pride.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FNEt/\n",
+  "description": "",
+  "quality_notes": "",
+  "language": "English",
+  "copyright_text": "",
+  "thumbnail_url": "https://i.ytimg.com/vi/URztqq1kiqI/maxresdefault.jpg",
+  "duration": 2524,
   "videos": [
     {
-      "url": "https://www.youtube.com/watch?v=URztqq1kiqI", 
-      "length": 0, 
+      "url": "https://www.youtube.com/watch?v=URztqq1kiqI",
+      "length": 0,
       "type": "youtube"
     }
-  ], 
-  "source_url": "https://www.youtube.com/watch?v=URztqq1kiqI", 
-  "tags": [], 
+  ],
+  "source_url": "https://www.youtube.com/watch?v=URztqq1kiqI",
+  "tags": [],
   "speakers": [
     "Casey Kinsey"
-  ], 
+  ],
   "recorded": "2014-09-13"
 }

--- a/data/djangocon-2014/videos/integrating-django-and-wordpress-can-be-simple.json
+++ b/data/djangocon-2014/videos/integrating-django-and-wordpress-can-be-simple.json
@@ -1,25 +1,25 @@
 {
-  "category": "DjangoCon 2014", 
-  "slug": "integrating-django-and-wordpress-can-be-simple", 
-  "title": "Integrating Django and WordPress can be simple.", 
-  "summary": "I found it surprisingly easy to do a simple integration of Django with an existing WordPress blog. I use Django to display content from WordPress\u2019s database. I\u2019ll explain how I integrated them and what made things easy.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FOPW/", 
-  "description": "", 
-  "quality_notes": "", 
-  "language": "English", 
-  "copyright_text": "", 
-  "thumbnail_url": "https://i.ytimg.com/vi/agXtM_YJlxg/maxresdefault.jpg", 
-  "duration": 1657, 
+  "category": "DjangoCon 2014",
+  "slug": "integrating-django-and-wordpress-can-be-simple",
+  "title": "Integrating Django and WordPress can be simple.",
+  "summary": "I found it surprisingly easy to do a simple integration of Django with\nan existing WordPress blog. I use Django to display content from\nWordPress\u2019s database. I\u2019ll explain how I integrated them and what made\nthings easy.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FOPW/\n",
+  "description": "",
+  "quality_notes": "",
+  "language": "English",
+  "copyright_text": "",
+  "thumbnail_url": "https://i.ytimg.com/vi/agXtM_YJlxg/maxresdefault.jpg",
+  "duration": 1657,
   "videos": [
     {
-      "url": "https://www.youtube.com/watch?v=agXtM_YJlxg", 
-      "length": 0, 
+      "url": "https://www.youtube.com/watch?v=agXtM_YJlxg",
+      "length": 0,
       "type": "youtube"
     }
-  ], 
-  "source_url": "https://www.youtube.com/watch?v=agXtM_YJlxg", 
-  "tags": [], 
+  ],
+  "source_url": "https://www.youtube.com/watch?v=agXtM_YJlxg",
+  "tags": [],
   "speakers": [
     "Collin Anderson"
-  ], 
+  ],
   "recorded": "2014-09-16"
 }

--- a/data/djangocon-2014/videos/json-web-tokens.json
+++ b/data/djangocon-2014/videos/json-web-tokens.json
@@ -1,25 +1,25 @@
 {
-  "category": "DjangoCon 2014", 
-  "slug": "json-web-tokens", 
-  "title": "JSON Web Tokens", 
-  "summary": "When it comes to implementing authentication on web apps, one solution you\u2019ll definitely hear about first are cookies. Cookie-based authentication uses a server side cookies to authenticate the user on every request. A solution you\u2019ll probably not hear as often is token-based authentication which relies on a signed token that is sent to the server on each request.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FQmX/", 
-  "description": "", 
-  "quality_notes": "", 
-  "language": "English", 
-  "copyright_text": "", 
-  "thumbnail_url": "https://i.ytimg.com/vi/825hodQ61bg/maxresdefault.jpg", 
-  "duration": 1341, 
+  "category": "DjangoCon 2014",
+  "slug": "json-web-tokens",
+  "title": "JSON Web Tokens",
+  "summary": "When it comes to implementing authentication on web apps, one solution\nyou\u2019ll definitely hear about first are cookies. Cookie-based\nauthentication uses a server side cookies to authenticate the user on\nevery request. A solution you\u2019ll probably not hear as often is\ntoken-based authentication which relies on a signed token that is sent\nto the server on each request.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FQmX/\n",
+  "description": "",
+  "quality_notes": "",
+  "language": "English",
+  "copyright_text": "",
+  "thumbnail_url": "https://i.ytimg.com/vi/825hodQ61bg/maxresdefault.jpg",
+  "duration": 1341,
   "videos": [
     {
-      "url": "https://www.youtube.com/watch?v=825hodQ61bg", 
-      "length": 0, 
+      "url": "https://www.youtube.com/watch?v=825hodQ61bg",
+      "length": 0,
       "type": "youtube"
     }
-  ], 
-  "source_url": "https://www.youtube.com/watch?v=825hodQ61bg", 
-  "tags": [], 
+  ],
+  "source_url": "https://www.youtube.com/watch?v=825hodQ61bg",
+  "tags": [],
   "speakers": [
     "Jos\u00e9 Padilla"
-  ], 
+  ],
   "recorded": "2014-09-24"
 }

--- a/data/djangocon-2014/videos/liberation-and-modernization-of-government-legacy.json
+++ b/data/djangocon-2014/videos/liberation-and-modernization-of-government-legacy.json
@@ -1,25 +1,25 @@
 {
-  "category": "DjangoCon 2014", 
-  "slug": "liberation-and-modernization-of-government-legacy", 
-  "title": "Liberation and modernization of government legacy data using Django", 
-  "summary": "How the government of Puerto Rico is making the release of government data and interagency electronic communication a reality using Django and a stack of Django and Python tools and libraries. This effort resulted in the creation of the LIBRE API engine.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FQmZ/", 
-  "description": "", 
-  "quality_notes": "", 
-  "language": "English", 
-  "copyright_text": "", 
-  "thumbnail_url": "https://i.ytimg.com/vi/P4qCp_js2aA/maxresdefault.jpg", 
-  "duration": 2064, 
+  "category": "DjangoCon 2014",
+  "slug": "liberation-and-modernization-of-government-legacy",
+  "title": "Liberation and modernization of government legacy data using Django",
+  "summary": "How the government of Puerto Rico is making the release of government\ndata and interagency electronic communication a reality using Django and\na stack of Django and Python tools and libraries. This effort resulted\nin the creation of the LIBRE API engine.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FQmZ/\n",
+  "description": "",
+  "quality_notes": "",
+  "language": "English",
+  "copyright_text": "",
+  "thumbnail_url": "https://i.ytimg.com/vi/P4qCp_js2aA/maxresdefault.jpg",
+  "duration": 2064,
   "videos": [
     {
-      "url": "https://www.youtube.com/watch?v=P4qCp_js2aA", 
-      "length": 0, 
+      "url": "https://www.youtube.com/watch?v=P4qCp_js2aA",
+      "length": 0,
       "type": "youtube"
     }
-  ], 
-  "source_url": "https://www.youtube.com/watch?v=P4qCp_js2aA", 
-  "tags": [], 
+  ],
+  "source_url": "https://www.youtube.com/watch?v=P4qCp_js2aA",
+  "tags": [],
   "speakers": [
     "Roberto Rosario"
-  ], 
+  ],
   "recorded": "2014-09-24"
 }

--- a/data/djangocon-2014/videos/lightning-talks.json
+++ b/data/djangocon-2014/videos/lightning-talks.json
@@ -2,7 +2,7 @@
   "category": "DjangoCon 2014",
   "slug": "lightning-talks",
   "title": "Lightning Talks",
-  "summary": "Help us caption & translate this video!\n\nhttp://amara.org/v/FQm0/",
+  "summary": "Help us caption & translate this video!\n\nhttp://amara.org/v/FQm0/\n",
   "description": "",
   "quality_notes": "",
   "language": "English",

--- a/data/djangocon-2014/videos/oauth2-and-django-what-you-should-know.json
+++ b/data/djangocon-2014/videos/oauth2-and-django-what-you-should-know.json
@@ -1,25 +1,25 @@
 {
-  "category": "DjangoCon 2014", 
-  "slug": "oauth2-and-django-what-you-should-know", 
-  "title": "OAuth2 and Django, What You Should Know", 
-  "summary": "OAuth 2.0 is the current version of OAuth, a hotly debated open standard for authorization. Implementing it allows your users to grant access to their data to other services, turning your collection of services into a platform. In this talk I will discuss the options you have for creating your own OAuth 2.0 components with Django, how to use them, and common implementation mistakes.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FOP5/", 
-  "description": "", 
-  "quality_notes": "", 
-  "language": "English", 
-  "copyright_text": "", 
-  "thumbnail_url": "https://i.ytimg.com/vi/nKmvRQVvNdI/maxresdefault.jpg", 
-  "duration": 1546, 
+  "category": "DjangoCon 2014",
+  "slug": "oauth2-and-django-what-you-should-know",
+  "title": "OAuth2 and Django, What You Should Know",
+  "summary": "OAuth 2.0 is the current version of OAuth, a hotly debated open standard\nfor authorization. Implementing it allows your users to grant access to\ntheir data to other services, turning your collection of services into a\nplatform. In this talk I will discuss the options you have for creating\nyour own OAuth 2.0 components with Django, how to use them, and common\nimplementation mistakes.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FOP5/\n",
+  "description": "",
+  "quality_notes": "",
+  "language": "English",
+  "copyright_text": "",
+  "thumbnail_url": "https://i.ytimg.com/vi/nKmvRQVvNdI/maxresdefault.jpg",
+  "duration": 1546,
   "videos": [
     {
-      "url": "https://www.youtube.com/watch?v=nKmvRQVvNdI", 
-      "length": 0, 
+      "url": "https://www.youtube.com/watch?v=nKmvRQVvNdI",
+      "length": 0,
       "type": "youtube"
     }
-  ], 
-  "source_url": "https://www.youtube.com/watch?v=nKmvRQVvNdI", 
-  "tags": [], 
+  ],
+  "source_url": "https://www.youtube.com/watch?v=nKmvRQVvNdI",
+  "tags": [],
   "speakers": [
     "Jharrod LaFon"
-  ], 
+  ],
   "recorded": "2014-09-17"
 }

--- a/data/djangocon-2014/videos/optimizing-your-webapp-by-using-django-debug.json
+++ b/data/djangocon-2014/videos/optimizing-your-webapp-by-using-django-debug.json
@@ -18,6 +18,8 @@
   ],
   "source_url": "https://www.youtube.com/watch?v=NqWcBFCcZ2M",
   "tags": [],
-  "speakers": [],
+  "speakers": [
+    "Christopher Adams"
+  ],
   "recorded": "2014-09-19"
 }

--- a/data/djangocon-2014/videos/optimizing-your-webapp-by-using-django-debug.json
+++ b/data/djangocon-2014/videos/optimizing-your-webapp-by-using-django-debug.json
@@ -1,23 +1,23 @@
 {
-  "category": "DjangoCon 2014", 
-  "slug": "optimizing-your-webapp-by-using-django-debug", 
-  "title": "Optimizing your webapp by using django-debug-toolbar", 
-  "summary": "This talk explains how to perform SQL query analysis and how to rewrite your views to reduce the number of queries Django uses in evaluating your model objects and their attributes. Special emphasis will be given to the powerful methods \"select_related\" and \"prefetch_related.\" I will highlight the problem with a naive use of the ORM, how to target code for optimization, and the beneficial result.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FPWg/", 
-  "description": "", 
-  "quality_notes": "", 
-  "language": "English", 
-  "copyright_text": "", 
-  "thumbnail_url": "https://i.ytimg.com/vi/NqWcBFCcZ2M/maxresdefault.jpg", 
-  "duration": 1370, 
+  "category": "DjangoCon 2014",
+  "slug": "optimizing-your-webapp-by-using-django-debug",
+  "title": "Optimizing your webapp by using django-debug-toolbar",
+  "summary": "This talk explains how to perform SQL query analysis and how to rewrite\nyour views to reduce the number of queries Django uses in evaluating\nyour model objects and their attributes. Special emphasis will be given\nto the powerful methods \"select\\_related\" and \"prefetch\\_related.\" I\nwill highlight the problem with a naive use of the ORM, how to target\ncode for optimization, and the beneficial result.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FPWg/\n",
+  "description": "",
+  "quality_notes": "",
+  "language": "English",
+  "copyright_text": "",
+  "thumbnail_url": "https://i.ytimg.com/vi/NqWcBFCcZ2M/maxresdefault.jpg",
+  "duration": 1370,
   "videos": [
     {
-      "url": "https://www.youtube.com/watch?v=NqWcBFCcZ2M", 
-      "length": 0, 
+      "url": "https://www.youtube.com/watch?v=NqWcBFCcZ2M",
+      "length": 0,
       "type": "youtube"
     }
-  ], 
-  "source_url": "https://www.youtube.com/watch?v=NqWcBFCcZ2M", 
-  "tags": [], 
-  "speakers": [], 
+  ],
+  "source_url": "https://www.youtube.com/watch?v=NqWcBFCcZ2M",
+  "tags": [],
+  "speakers": [],
   "recorded": "2014-09-19"
 }

--- a/data/djangocon-2014/videos/patterns-for-extensibility.json
+++ b/data/djangocon-2014/videos/patterns-for-extensibility.json
@@ -1,25 +1,25 @@
 {
-  "category": "DjangoCon 2014", 
-  "slug": "patterns-for-extensibility", 
-  "title": "Patterns for Extensibility", 
-  "summary": "How can I make my Django app extensible so it can be used beyond my original intent and gain wider adoption? Come learn how Eldarion has been making their apps extensible for greater reuse as well as wider adoption.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FPWk/\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FSPI/", 
-  "description": "", 
-  "quality_notes": "", 
-  "language": "English", 
-  "copyright_text": "", 
-  "thumbnail_url": "https://i.ytimg.com/vi/hmd_1pVYdyU/maxresdefault.jpg", 
-  "duration": 1127, 
+  "category": "DjangoCon 2014",
+  "slug": "patterns-for-extensibility",
+  "title": "Patterns for Extensibility",
+  "summary": "How can I make my Django app extensible so it can be used beyond my\noriginal intent and gain wider adoption? Come learn how Eldarion has\nbeen making their apps extensible for greater reuse as well as wider\nadoption.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FPWk/\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FSPI/\n",
+  "description": "",
+  "quality_notes": "",
+  "language": "English",
+  "copyright_text": "",
+  "thumbnail_url": "https://i.ytimg.com/vi/hmd_1pVYdyU/maxresdefault.jpg",
+  "duration": 1127,
   "videos": [
     {
-      "url": "https://www.youtube.com/watch?v=hmd_1pVYdyU", 
-      "length": 0, 
+      "url": "https://www.youtube.com/watch?v=hmd_1pVYdyU",
+      "length": 0,
       "type": "youtube"
     }
-  ], 
-  "source_url": "https://www.youtube.com/watch?v=hmd_1pVYdyU", 
-  "tags": [], 
+  ],
+  "source_url": "https://www.youtube.com/watch?v=hmd_1pVYdyU",
+  "tags": [],
   "speakers": [
     "Patrick Altman"
-  ], 
+  ],
   "recorded": "2014-09-26"
 }

--- a/data/djangocon-2014/videos/performant-django.json
+++ b/data/djangocon-2014/videos/performant-django.json
@@ -1,25 +1,25 @@
 {
-  "category": "DjangoCon 2014", 
-  "slug": "performant-django", 
-  "title": "Performant Django", 
-  "summary": "Since the days of version 1.0, the Django community has added countless features that address performance pain points; everything from cached template loaders to prefetch_related(), the staticfiles app to django-debug-toolbar. But how do you use these tools to make your site fast? In this talk we take a meandering survey through the Django/Python performance landscape.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FNEq/", 
-  "description": "", 
-  "quality_notes": "", 
-  "language": "English", 
-  "copyright_text": "", 
-  "thumbnail_url": "https://i.ytimg.com/vi/nhBGuf_KGGc/maxresdefault.jpg", 
-  "duration": 2218, 
+  "category": "DjangoCon 2014",
+  "slug": "performant-django",
+  "title": "Performant Django",
+  "summary": "Since the days of version 1.0, the Django community has added countless\nfeatures that address performance pain points; everything from cached\ntemplate loaders to prefetch\\_related(), the staticfiles app to\ndjango-debug-toolbar. But how do you use these tools to make your site\nfast? In this talk we take a meandering survey through the Django/Python\nperformance landscape.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FNEq/\n",
+  "description": "",
+  "quality_notes": "",
+  "language": "English",
+  "copyright_text": "",
+  "thumbnail_url": "https://i.ytimg.com/vi/nhBGuf_KGGc/maxresdefault.jpg",
+  "duration": 2218,
   "videos": [
     {
-      "url": "https://www.youtube.com/watch?v=nhBGuf_KGGc", 
-      "length": 0, 
+      "url": "https://www.youtube.com/watch?v=nhBGuf_KGGc",
+      "length": 0,
       "type": "youtube"
     }
-  ], 
-  "source_url": "https://www.youtube.com/watch?v=nhBGuf_KGGc", 
-  "tags": [], 
+  ],
+  "source_url": "https://www.youtube.com/watch?v=nhBGuf_KGGc",
+  "tags": [],
   "speakers": [
     "Ara Anjargolian"
-  ], 
+  ],
   "recorded": "2014-09-13"
 }

--- a/data/djangocon-2014/videos/practical-django-secuirty.json
+++ b/data/djangocon-2014/videos/practical-django-secuirty.json
@@ -1,25 +1,25 @@
 {
-  "category": "DjangoCon 2014", 
-  "slug": "practical-django-secuirty", 
-  "title": "Practical Django Secuirty", 
-  "summary": "Web application security is an ever present problem. The \"don't trust user input\" mantra sounds nice but doesn't practically work. In this talk we will go over introduce and apply a set of practical programming paradigms that you can use to write secure code.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FNEe/", 
-  "description": "", 
-  "quality_notes": "", 
-  "language": "English", 
-  "copyright_text": "", 
-  "thumbnail_url": "https://i.ytimg.com/vi/tcylo9qo9gA/maxresdefault.jpg", 
-  "duration": 2903, 
+  "category": "DjangoCon 2014",
+  "slug": "practical-django-secuirty",
+  "title": "Practical Django Secuirty",
+  "summary": "Web application security is an ever present problem. The \"don't trust\nuser input\" mantra sounds nice but doesn't practically work. In this\ntalk we will go over introduce and apply a set of practical programming\nparadigms that you can use to write secure code.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FNEe/\n",
+  "description": "",
+  "quality_notes": "",
+  "language": "English",
+  "copyright_text": "",
+  "thumbnail_url": "https://i.ytimg.com/vi/tcylo9qo9gA/maxresdefault.jpg",
+  "duration": 2903,
   "videos": [
     {
-      "url": "https://www.youtube.com/watch?v=tcylo9qo9gA", 
-      "length": 0, 
+      "url": "https://www.youtube.com/watch?v=tcylo9qo9gA",
+      "length": 0,
       "type": "youtube"
     }
-  ], 
-  "source_url": "https://www.youtube.com/watch?v=tcylo9qo9gA", 
-  "tags": [], 
+  ],
+  "source_url": "https://www.youtube.com/watch?v=tcylo9qo9gA",
+  "tags": [],
   "speakers": [
     "Levi Gross"
-  ], 
+  ],
   "recorded": "2014-09-11"
 }

--- a/data/djangocon-2014/videos/real-world-django-q-a.json
+++ b/data/djangocon-2014/videos/real-world-django-q-a.json
@@ -1,23 +1,23 @@
 {
-  "category": "DjangoCon 2014", 
-  "slug": "real-world-django-q-a", 
-  "title": "Real World Django Q&A", 
-  "summary": "Have questions about getting better performance out of Django or scaling it up large? We've assembled a group of knowledgable Django experts who have been there to answer the questions you have. While every site has its own challenges most follow similar patterns that are often easy to solve.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FOPS/", 
-  "description": "", 
-  "quality_notes": "", 
-  "language": "English", 
-  "copyright_text": "", 
-  "thumbnail_url": "https://i.ytimg.com/vi/SJoEgVstq2Q/maxresdefault.jpg", 
-  "duration": 2806, 
+  "category": "DjangoCon 2014",
+  "slug": "real-world-django-q-a",
+  "title": "Real World Django Q&A",
+  "summary": "Have questions about getting better performance out of Django or scaling\nit up large? We've assembled a group of knowledgable Django experts who\nhave been there to answer the questions you have. While every site has\nits own challenges most follow similar patterns that are often easy to\nsolve.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FOPS/\n",
+  "description": "",
+  "quality_notes": "",
+  "language": "English",
+  "copyright_text": "",
+  "thumbnail_url": "https://i.ytimg.com/vi/SJoEgVstq2Q/maxresdefault.jpg",
+  "duration": 2806,
   "videos": [
     {
-      "url": "https://www.youtube.com/watch?v=SJoEgVstq2Q", 
-      "length": 0, 
+      "url": "https://www.youtube.com/watch?v=SJoEgVstq2Q",
+      "length": 0,
       "type": "youtube"
     }
-  ], 
-  "source_url": "https://www.youtube.com/watch?v=SJoEgVstq2Q", 
-  "tags": [], 
-  "speakers": [], 
+  ],
+  "source_url": "https://www.youtube.com/watch?v=SJoEgVstq2Q",
+  "tags": [],
+  "speakers": [],
   "recorded": "2014-09-16"
 }

--- a/data/djangocon-2014/videos/real-world-django-q-a.json
+++ b/data/djangocon-2014/videos/real-world-django-q-a.json
@@ -18,6 +18,11 @@
   ],
   "source_url": "https://www.youtube.com/watch?v=SJoEgVstq2Q",
   "tags": [],
-  "speakers": [],
+  "speakers": [
+    "Andrew Godwin",
+    "Frank Wiles",
+    "Honza Kr\u00e1l",
+    "Peter Baumgartner"
+  ],
   "recorded": "2014-09-16"
 }

--- a/data/djangocon-2014/videos/regulating-the-securities-market-with-django-and.json
+++ b/data/djangocon-2014/videos/regulating-the-securities-market-with-django-and.json
@@ -1,25 +1,25 @@
 {
-  "category": "DjangoCon 2014", 
-  "slug": "regulating-the-securities-market-with-django-and", 
-  "title": "REGULATING THE SECURITIES MARKET WITH DJANGO AND PANDAS", 
-  "summary": "Developing applications for civil service organizations can be uniquely challenging. The presentation discusses our experience with MASS a market surveillance and monitoring application developed for the TTSEC. MASS is based on Django and Pandas. We highlight not only the techinal aspects of the solution but also address the HR and organizational factors that impacted on the project\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FOP3/", 
-  "description": "", 
-  "quality_notes": "", 
-  "language": "English", 
-  "copyright_text": "", 
-  "thumbnail_url": "https://i.ytimg.com/vi/6AOGob_uxM8/maxresdefault.jpg", 
-  "duration": 1497, 
+  "category": "DjangoCon 2014",
+  "slug": "regulating-the-securities-market-with-django-and",
+  "title": "REGULATING THE SECURITIES MARKET WITH DJANGO AND PANDAS",
+  "summary": "Developing applications for civil service organizations can be uniquely\nchallenging. The presentation discusses our experience with MASS a\nmarket surveillance and monitoring application developed for the TTSEC.\nMASS is based on Django and Pandas. We highlight not only the techinal\naspects of the solution but also address the HR and organizational\nfactors that impacted on the project\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FOP3/\n",
+  "description": "",
+  "quality_notes": "",
+  "language": "English",
+  "copyright_text": "",
+  "thumbnail_url": "https://i.ytimg.com/vi/6AOGob_uxM8/maxresdefault.jpg",
+  "duration": 1497,
   "videos": [
     {
-      "url": "https://www.youtube.com/watch?v=6AOGob_uxM8", 
-      "length": 0, 
+      "url": "https://www.youtube.com/watch?v=6AOGob_uxM8",
+      "length": 0,
       "type": "youtube"
     }
-  ], 
-  "source_url": "https://www.youtube.com/watch?v=6AOGob_uxM8", 
-  "tags": [], 
+  ],
+  "source_url": "https://www.youtube.com/watch?v=6AOGob_uxM8",
+  "tags": [],
   "speakers": [
     "Christopher Clarke"
-  ], 
+  ],
   "recorded": "2014-09-17"
 }

--- a/data/djangocon-2014/videos/rest-its-not-just-for-servers.json
+++ b/data/djangocon-2014/videos/rest-its-not-just-for-servers.json
@@ -1,25 +1,25 @@
 {
-  "category": "DjangoCon 2014", 
-  "slug": "rest-its-not-just-for-servers", 
-  "title": "REST: It's not just for servers", 
-  "summary": "Have you ever written or used an API wrapper for a webservice? REST is a client-server architecture model and building the server is only half of the challenge. This talk will walk through some of the challenges of building a REST client, describe some best practices and some patterns to avoid, and discuss how we can all work to build better APIs for an open web.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FPWl/", 
-  "description": "", 
-  "quality_notes": "", 
-  "language": "English", 
-  "copyright_text": "", 
-  "thumbnail_url": "https://i.ytimg.com/vi/j4rZAlLZfj4/maxresdefault.jpg", 
-  "duration": 2155, 
+  "category": "DjangoCon 2014",
+  "slug": "rest-its-not-just-for-servers",
+  "title": "REST: It's not just for servers",
+  "summary": "Have you ever written or used an API wrapper for a webservice? REST is a\nclient-server architecture model and building the server is only half of\nthe challenge. This talk will walk through some of the challenges of\nbuilding a REST client, describe some best practices and some patterns\nto avoid, and discuss how we can all work to build better APIs for an\nopen web.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FPWl/\n",
+  "description": "",
+  "quality_notes": "",
+  "language": "English",
+  "copyright_text": "",
+  "thumbnail_url": "https://i.ytimg.com/vi/j4rZAlLZfj4/maxresdefault.jpg",
+  "duration": 2155,
   "videos": [
     {
-      "url": "https://www.youtube.com/watch?v=j4rZAlLZfj4", 
-      "length": 0, 
+      "url": "https://www.youtube.com/watch?v=j4rZAlLZfj4",
+      "length": 0,
       "type": "youtube"
     }
-  ], 
-  "source_url": "https://www.youtube.com/watch?v=j4rZAlLZfj4", 
-  "tags": [], 
+  ],
+  "source_url": "https://www.youtube.com/watch?v=j4rZAlLZfj4",
+  "tags": [],
   "speakers": [
     "Mark Lavin"
-  ], 
+  ],
   "recorded": "2014-09-19"
 }

--- a/data/djangocon-2014/videos/setting-up-your-development-environment-for-django.json
+++ b/data/djangocon-2014/videos/setting-up-your-development-environment-for-django.json
@@ -1,26 +1,26 @@
 {
-  "category": "DjangoCon 2014", 
-  "slug": "setting-up-your-development-environment-for-django", 
-  "title": "Setting up your development environment for Django", 
-  "summary": "First steps and best practices for getting a reproduceable environment for Django development!\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FOP0/", 
-  "description": "", 
-  "quality_notes": "", 
-  "language": "English", 
-  "copyright_text": "", 
-  "thumbnail_url": "https://i.ytimg.com/vi/YZ_xC8FwcUY/maxresdefault.jpg", 
-  "duration": 1803, 
+  "category": "DjangoCon 2014",
+  "slug": "setting-up-your-development-environment-for-django",
+  "title": "Setting up your development environment for Django",
+  "summary": "First steps and best practices for getting a reproduceable environment\nfor Django development!\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FOP0/\n",
+  "description": "",
+  "quality_notes": "",
+  "language": "English",
+  "copyright_text": "",
+  "thumbnail_url": "https://i.ytimg.com/vi/YZ_xC8FwcUY/maxresdefault.jpg",
+  "duration": 1803,
   "videos": [
     {
-      "url": "https://www.youtube.com/watch?v=YZ_xC8FwcUY", 
-      "length": 0, 
+      "url": "https://www.youtube.com/watch?v=YZ_xC8FwcUY",
+      "length": 0,
       "type": "youtube"
     }
-  ], 
-  "source_url": "https://www.youtube.com/watch?v=YZ_xC8FwcUY", 
-  "tags": [], 
+  ],
+  "source_url": "https://www.youtube.com/watch?v=YZ_xC8FwcUY",
+  "tags": [],
   "speakers": [
-    "Ramon Maria Gallart Escol\u00e0", 
+    "Ramon Maria Gallart Escol\u00e0",
     "Greg Robbins"
-  ], 
+  ],
   "recorded": "2014-09-16"
 }

--- a/data/djangocon-2014/videos/technical-onboarding-training-and-mentoring.json
+++ b/data/djangocon-2014/videos/technical-onboarding-training-and-mentoring.json
@@ -1,25 +1,25 @@
 {
-  "category": "DjangoCon 2014", 
-  "slug": "technical-onboarding-training-and-mentoring", 
-  "title": "Technical Onboarding, Training, and Mentoring", 
-  "summary": "With the increase of code academies training new engineers there is an increase in junior engineers on the market. A lot of companies are hesitant to hire too many young engineers because they lack sufficient resources to train them.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FPWe/", 
-  "description": "", 
-  "quality_notes": "", 
-  "language": "English", 
-  "copyright_text": "", 
-  "thumbnail_url": "https://i.ytimg.com/vi/B1dZ3AjRJJI/maxresdefault.jpg", 
-  "duration": 1704, 
+  "category": "DjangoCon 2014",
+  "slug": "technical-onboarding-training-and-mentoring",
+  "title": "Technical Onboarding, Training, and Mentoring",
+  "summary": "With the increase of code academies training new engineers there is an\nincrease in junior engineers on the market. A lot of companies are\nhesitant to hire too many young engineers because they lack sufficient\nresources to train them.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FPWe/\n",
+  "description": "",
+  "quality_notes": "",
+  "language": "English",
+  "copyright_text": "",
+  "thumbnail_url": "https://i.ytimg.com/vi/B1dZ3AjRJJI/maxresdefault.jpg",
+  "duration": 1704,
   "videos": [
     {
-      "url": "https://www.youtube.com/watch?v=B1dZ3AjRJJI", 
-      "length": 0, 
+      "url": "https://www.youtube.com/watch?v=B1dZ3AjRJJI",
+      "length": 0,
       "type": "youtube"
     }
-  ], 
-  "source_url": "https://www.youtube.com/watch?v=B1dZ3AjRJJI", 
-  "tags": [], 
+  ],
+  "source_url": "https://www.youtube.com/watch?v=B1dZ3AjRJJI",
+  "tags": [],
   "speakers": [
     "Kate Heddleston"
-  ], 
+  ],
   "recorded": "2014-09-18"
 }

--- a/data/djangocon-2014/videos/the-evolution-of-a-restful-django-backend.json
+++ b/data/djangocon-2014/videos/the-evolution-of-a-restful-django-backend.json
@@ -1,25 +1,25 @@
 {
-  "category": "DjangoCon 2014", 
-  "slug": "the-evolution-of-a-restful-django-backend", 
-  "title": "The evolution of a RESTful Django backend", 
-  "summary": "A look at the challenges and successes that the Safari Books Online team has had implementing RESTful web services in Django.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FOPY/", 
-  "description": "", 
-  "quality_notes": "", 
-  "language": "English", 
-  "copyright_text": "", 
-  "thumbnail_url": "https://i.ytimg.com/vi/zlfSCdu0y6s/maxresdefault.jpg", 
-  "duration": 1476, 
+  "category": "DjangoCon 2014",
+  "slug": "the-evolution-of-a-restful-django-backend",
+  "title": "The evolution of a RESTful Django backend",
+  "summary": "A look at the challenges and successes that the Safari Books Online team\nhas had implementing RESTful web services in Django.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FOPY/\n",
+  "description": "",
+  "quality_notes": "",
+  "language": "English",
+  "copyright_text": "",
+  "thumbnail_url": "https://i.ytimg.com/vi/zlfSCdu0y6s/maxresdefault.jpg",
+  "duration": 1476,
   "videos": [
     {
-      "url": "https://www.youtube.com/watch?v=zlfSCdu0y6s", 
-      "length": 0, 
+      "url": "https://www.youtube.com/watch?v=zlfSCdu0y6s",
+      "length": 0,
       "type": "youtube"
     }
-  ], 
-  "source_url": "https://www.youtube.com/watch?v=zlfSCdu0y6s", 
-  "tags": [], 
+  ],
+  "source_url": "https://www.youtube.com/watch?v=zlfSCdu0y6s",
+  "tags": [],
   "speakers": [
     "Andrew Brookins"
-  ], 
+  ],
   "recorded": "2014-09-16"
 }

--- a/data/djangocon-2014/videos/top-tips-for-developing-and-deploying-on-aws.json
+++ b/data/djangocon-2014/videos/top-tips-for-developing-and-deploying-on-aws.json
@@ -1,25 +1,25 @@
 {
-  "category": "DjangoCon 2014", 
-  "slug": "top-tips-for-developing-and-deploying-on-aws", 
-  "title": "Top tips for developing and deploying on AWS", 
-  "summary": "Amazon Web Services (AWS) is the leader in cloud computing. The AWS service offering is vast and continually evolving. As AWS grows so does the pace of innovation, there are hundreds of updates every year. Keeping up with the changes is not trivial. This talk will highlight top tips for both new and experienced users of AWS with a view to deploying a website, powered by Django naturally.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FNEu/", 
-  "description": "", 
-  "quality_notes": "", 
-  "language": "English", 
-  "copyright_text": "", 
-  "thumbnail_url": "https://i.ytimg.com/vi/gT4oC6QyN2Q/maxresdefault.jpg", 
-  "duration": 1398, 
+  "category": "DjangoCon 2014",
+  "slug": "top-tips-for-developing-and-deploying-on-aws",
+  "title": "Top tips for developing and deploying on AWS",
+  "summary": "Amazon Web Services (AWS) is the leader in cloud computing. The AWS\nservice offering is vast and continually evolving. As AWS grows so does\nthe pace of innovation, there are hundreds of updates every year.\nKeeping up with the changes is not trivial. This talk will highlight top\ntips for both new and experienced users of AWS with a view to deploying\na website, powered by Django naturally.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FNEu/\n",
+  "description": "",
+  "quality_notes": "",
+  "language": "English",
+  "copyright_text": "",
+  "thumbnail_url": "https://i.ytimg.com/vi/gT4oC6QyN2Q/maxresdefault.jpg",
+  "duration": 1398,
   "videos": [
     {
-      "url": "https://www.youtube.com/watch?v=gT4oC6QyN2Q", 
-      "length": 0, 
+      "url": "https://www.youtube.com/watch?v=gT4oC6QyN2Q",
+      "length": 0,
       "type": "youtube"
     }
-  ], 
-  "source_url": "https://www.youtube.com/watch?v=gT4oC6QyN2Q", 
-  "tags": [], 
+  ],
+  "source_url": "https://www.youtube.com/watch?v=gT4oC6QyN2Q",
+  "tags": [],
   "speakers": [
     "Craig Bruce"
-  ], 
+  ],
   "recorded": "2014-09-13"
 }

--- a/data/djangocon-2014/videos/upgrading-django-to-1-7.json
+++ b/data/djangocon-2014/videos/upgrading-django-to-1-7.json
@@ -1,25 +1,25 @@
 {
-  "category": "DjangoCon 2014", 
-  "slug": "upgrading-django-to-1-7", 
-  "title": "Upgrading Django (to 1.7)", 
-  "summary": "Want to learn about Django 1.7 and how to upgrade Django? Are you unclear on what the numbers 1.7 mean or how Django rolls out new versions? Find upgrading daunting? Want to better keep up with changes being made in Django? This talk is for you.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FOP4/", 
-  "description": "", 
-  "quality_notes": "", 
-  "language": "English", 
-  "copyright_text": "", 
-  "thumbnail_url": "https://i.ytimg.com/vi/bjIXZ-XX2SM/maxresdefault.jpg", 
-  "duration": 2716, 
+  "category": "DjangoCon 2014",
+  "slug": "upgrading-django-to-1-7",
+  "title": "Upgrading Django (to 1.7)",
+  "summary": "Want to learn about Django 1.7 and how to upgrade Django? Are you\nunclear on what the numbers 1.7 mean or how Django rolls out new\nversions? Find upgrading daunting? Want to better keep up with changes\nbeing made in Django? This talk is for you.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FOP4/\n",
+  "description": "",
+  "quality_notes": "",
+  "language": "English",
+  "copyright_text": "",
+  "thumbnail_url": "https://i.ytimg.com/vi/bjIXZ-XX2SM/maxresdefault.jpg",
+  "duration": 2716,
   "videos": [
     {
-      "url": "https://www.youtube.com/watch?v=bjIXZ-XX2SM", 
-      "length": 0, 
+      "url": "https://www.youtube.com/watch?v=bjIXZ-XX2SM",
+      "length": 0,
       "type": "youtube"
     }
-  ], 
-  "source_url": "https://www.youtube.com/watch?v=bjIXZ-XX2SM", 
-  "tags": [], 
+  ],
+  "source_url": "https://www.youtube.com/watch?v=bjIXZ-XX2SM",
+  "tags": [],
   "speakers": [
     "Andrew Pinkham"
-  ], 
+  ],
   "recorded": "2014-09-17"
 }

--- a/data/djangocon-2014/videos/what-is-the-django-admin-good-for.json
+++ b/data/djangocon-2014/videos/what-is-the-django-admin-good-for.json
@@ -1,25 +1,25 @@
 {
-  "category": "DjangoCon 2014", 
-  "slug": "what-is-the-django-admin-good-for", 
-  "title": "What is the Django admin good for?", 
-  "summary": "The Django admin is often cited as one of Django's great strengths. With virtually no coding, you have a functional web interface to administer your data. However, the admin should not be your (whole) web site. This talk discusses when you should use the admin and when you should not, admim customization features from basic to advanced, and how to grow beyond the admin (even for administration).\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FQmY/", 
-  "description": "", 
-  "quality_notes": "", 
-  "language": "English", 
-  "copyright_text": "", 
-  "thumbnail_url": "https://i.ytimg.com/vi/Eroja7Gw4_k/maxresdefault.jpg", 
-  "duration": 2450, 
+  "category": "DjangoCon 2014",
+  "slug": "what-is-the-django-admin-good-for",
+  "title": "What is the Django admin good for?",
+  "summary": "The Django admin is often cited as one of Django's great strengths. With\nvirtually no coding, you have a functional web interface to administer\nyour data. However, the admin should not be your (whole) web site. This\ntalk discusses when you should use the admin and when you should not,\nadmim customization features from basic to advanced, and how to grow\nbeyond the admin (even for administration).\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FQmY/\n",
+  "description": "",
+  "quality_notes": "",
+  "language": "English",
+  "copyright_text": "",
+  "thumbnail_url": "https://i.ytimg.com/vi/Eroja7Gw4_k/maxresdefault.jpg",
+  "duration": 2450,
   "videos": [
     {
-      "url": "https://www.youtube.com/watch?v=Eroja7Gw4_k", 
-      "length": 0, 
+      "url": "https://www.youtube.com/watch?v=Eroja7Gw4_k",
+      "length": 0,
       "type": "youtube"
     }
-  ], 
-  "source_url": "https://www.youtube.com/watch?v=Eroja7Gw4_k", 
-  "tags": [], 
+  ],
+  "source_url": "https://www.youtube.com/watch?v=Eroja7Gw4_k",
+  "tags": [],
   "speakers": [
     "Karen Tracey"
-  ], 
+  ],
   "recorded": "2014-09-24"
 }

--- a/data/djangocon-2014/videos/you-shipped-it-you-fix-it.json
+++ b/data/djangocon-2014/videos/you-shipped-it-you-fix-it.json
@@ -1,25 +1,25 @@
 {
-  "category": "DjangoCon 2014", 
-  "slug": "you-shipped-it-you-fix-it", 
-  "title": "You shipped it, you fix it", 
-  "summary": "This talk will explain and showcase how improving transparency and accountability in development teams can significantly improve the culture in the team and improve the quality of the code that gets released.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FNEm/", 
-  "description": "", 
-  "quality_notes": "", 
-  "language": "English", 
-  "copyright_text": "", 
-  "thumbnail_url": "https://i.ytimg.com/vi/_p_Iq2AnLoA/maxresdefault.jpg", 
-  "duration": 747, 
+  "category": "DjangoCon 2014",
+  "slug": "you-shipped-it-you-fix-it",
+  "title": "You shipped it, you fix it",
+  "summary": "This talk will explain and showcase how improving transparency and\naccountability in development teams can significantly improve the\nculture in the team and improve the quality of the code that gets\nreleased.\n\nHelp us caption & translate this video!\n\nhttp://amara.org/v/FNEm/\n",
+  "description": "",
+  "quality_notes": "",
+  "language": "English",
+  "copyright_text": "",
+  "thumbnail_url": "https://i.ytimg.com/vi/_p_Iq2AnLoA/maxresdefault.jpg",
+  "duration": 747,
   "videos": [
     {
-      "url": "https://www.youtube.com/watch?v=_p_Iq2AnLoA", 
-      "length": 0, 
+      "url": "https://www.youtube.com/watch?v=_p_Iq2AnLoA",
+      "length": 0,
       "type": "youtube"
     }
-  ], 
-  "source_url": "https://www.youtube.com/watch?v=_p_Iq2AnLoA", 
-  "tags": [], 
+  ],
+  "source_url": "https://www.youtube.com/watch?v=_p_Iq2AnLoA",
+  "tags": [],
   "speakers": [
     "Ron Cohen"
-  ], 
+  ],
   "recorded": "2014-09-13"
 }


### PR DESCRIPTION
Continuation of #31 + #107

FTR, this is the script I used, using `pyandoc`

```
from clive import lib
import pypandoc

def convert_md2rst(string):
    return pypandoc.convert(string, 'rst', format='md')

def main():
    keys = {'summary', 'description'}
    data = lib.load_json_data('data/djangocon-2014')
    for path, info in data:
        for key in keys:
            string = info.get(key) or ''
            if string.strip():
                new_string = convert_md2rst(string)
                if new_string != string:
                    info[key] = new_string

    lib.save_json_data(data)

main()
```

Note: I also added this to clive.lib to remove [the extra trailing space](https://github.com/pyvideo/pyvideo-data/pull/107#discussion_r62556987) on each json line:

```
diff --git a/src/clive/lib.py b/src/clive/lib.py
index 7b93d3e..de8a26f 100644
--- a/src/clive/lib.py
+++ b/src/clive/lib.py
@@ -83,4 +83,5 @@ def save_json_data(data_items):
     for fn, data in data_items:
         with open(fn, 'w') as fp:
             json.dump(reorder_dict(data), fp, indent=2, sort_keys=False,
-                      default=json_convert)
+                      default=json_convert,
+                      separators=(',', ': '))

```

I'll submit a PR for this
