### PR TITLE
[clive.lib] Prevent trailing space at end of lines in saved JSON files

### DIFF
--- a/src/clive/lib.py
+++ b/src/clive/lib.py
@@ -83,4 +83,5 @@ def save_json_data(data_items):
     for fn, data in data_items:
         with open(fn, 'w') as fp:
             json.dump(reorder_dict(data), fp, indent=2, sort_keys=False,
-                      default=json_convert)
+                      default=json_convert,
+                      separators=(',', ': '))


### PR DESCRIPTION
After [reading this](https://docs.python.org/2/library/json.html#json.JSONEncoder):

```
Note Since the default item separator is ', ',
the output might include trailing whitespace when indent is specified. 
You can use separators=(',', ': ') to avoid this.
```
